### PR TITLE
Add lint and test ci

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,44 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: 3.*
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'

--- a/charts/tf-controller/Chart.yaml
+++ b/charts/tf-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tf-controller
 description: A Helm chart for TF-controller
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "0.7.0"

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,4 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+validate-maintainers: false


### PR DESCRIPTION
Adding linting and testing of the chart for every PR. 
The action will skip the actual lint and test steps if it does not detect any changes to the chart itself. 